### PR TITLE
Generally improve Right function stuff

### DIFF
--- a/gap/test_right.tst
+++ b/gap/test_right.tst
@@ -3,17 +3,17 @@ gap> Read("~/Documents/project/right_alg.g");
 gap> a := "aaaabbaac";
 "aaaabbaac"
 gap> Right(a, 2);
-[ 8, 8, 8, 8, 8, 8, 9, 9, -1 ]
+[ 8, 8, 8, 8, 8, 8, 9, 9, fail ]
 gap> Right(a, 3);
-[ 9, 9, 9, 9, 9, 9, -1, -1, -1 ]
+[ 9, 9, 9, 9, 9, 9, fail, fail, fail ]
 gap> b := "aaabcbcbdbcbabcd";
 "aaabcbcbdbcbabcd"
 gap> Right(b, 2);
-[ 4, 4, 4, 8, 8, 8, 8, 10, 10, 12, 12, 14, 14, 15, 16, -1 ]
-gap> a := "aasdfgfdsasdfwgfdrgh";
-"aasdfgfdsasdfwgfdrgh"
+[ 4, 4, 4, 8, 8, 8, 8, 10, 10, 12, 12, 14, 14, 15, 16, fail ]
+gap>  a := "aasdfgfdsasdfwgfd";
+"aasdfgfdsasdfwgfd"
 gap> Right(a, 4);
-[ 5, 5, 9, 9, 9, 9, 13, 13, 13, 13, 14, 17, 17, 17, 19, 19, 20, -1, -1, -1 ]
+[ 5, 5, 9, 9, 9, 9, 13, 13, 13, 13, 14, 17, 17, 17, fail, fail, fail ]
 gap> w := "a";
 "a"
 gap> Right(w, 1);
@@ -21,15 +21,15 @@ gap> Right(w, 1);
 gap> Left(w, 1);
 [ 1 ]
 gap> Right(w, 2);
-[ -1 ]
+[ fail ]
 gap> Right(w, 100);
-[ -1 ]
+[ fail ]
 gap> w := "aab";
 "aab"
 gap> Left(w, 2);
-[ -1, -1, 1 ]
+[ fail, fail, 1 ]
 gap> Right(w, 2);
-[ 3, 3, -1 ]
+[ 3, 3, fail ]
 gap> w := "";
 ""
 gap> Right(w, 1);
@@ -41,4 +41,4 @@ gap> Right(w, 4);
 gap> w := "hellothere";
 "hellothere"
 gap> Left(w, 4);
-[ -1, -1, -1, -1, 1, 2, 3, 5, 6, 6 ]
+[ fail, fail, fail, fail, 1, 2, 3, 5, 6, 6 ]

--- a/gap/test_right.tst
+++ b/gap/test_right.tst
@@ -1,21 +1,28 @@
 # test file for right function
-gap> Read("~/Documents/project/right_alg.g");
 gap> a := "aaaabbaac";
 "aaaabbaac"
+gap> a := StringToStandardListOfPosInts(a);
+[ 1, 1, 1, 1, 2, 2, 1, 1, 3 ]
 gap> Right(a, 2);
 [ 8, 8, 8, 8, 8, 8, 9, 9, fail ]
 gap> Right(a, 3);
 [ 9, 9, 9, 9, 9, 9, fail, fail, fail ]
 gap> b := "aaabcbcbdbcbabcd";
 "aaabcbcbdbcbabcd"
+gap> b := StringToStandardListOfPosInts(b);
+[ 1, 1, 1, 2, 3, 2, 3, 2, 4, 2, 3, 2, 1, 2, 3, 4 ]
 gap> Right(b, 2);
 [ 4, 4, 4, 8, 8, 8, 8, 10, 10, 12, 12, 14, 14, 15, 16, fail ]
 gap>  a := "aasdfgfdsasdfwgfd";
 "aasdfgfdsasdfwgfd"
+gap> a := StringToStandardListOfPosInts(a);
+[ 1, 1, 2, 3, 4, 5, 4, 3, 2, 1, 2, 3, 4, 6, 5, 4, 3 ]
 gap> Right(a, 4);
 [ 5, 5, 9, 9, 9, 9, 13, 13, 13, 13, 14, 17, 17, 17, fail, fail, fail ]
 gap> w := "a";
 "a"
+gap> w := StringToStandardListOfPosInts(w);
+[ 1 ]
 gap> Right(w, 1);
 [ 1 ]
 gap> Left(w, 1);
@@ -26,19 +33,23 @@ gap> Right(w, 100);
 [ fail ]
 gap> w := "aab";
 "aab"
+gap> w := StringToStandardListOfPosInts(w);
+[ 1, 1, 2 ]
 gap> Left(w, 2);
 [ fail, fail, 1 ]
 gap> Right(w, 2);
 [ 3, 3, fail ]
 gap> w := "";
 ""
-gap> Right(w, 1);
+gap> w := StringToStandardListOfPosInts(w);
 [  ]
-gap> Right(w, 0);
+gap> Right(w, 1);
 [  ]
 gap> Right(w, 4);
 [  ]
 gap> w := "hellothere";
 "hellothere"
+gap> w := StringToStandardListOfPosInts(w);
+[ 1, 2, 3, 3, 4, 5, 1, 2, 6, 2 ]
 gap> Left(w, 4);
 [ fail, fail, fail, fail, 1, 2, 3, 5, 6, 6 ]


### PR DESCRIPTION
This pull request implements some of James's suggestions from the meeting earlier today. The `Right` function works in a cleaner way than it used to. I have added separate functions which convert strings and lists of positive integers into our 'standard' representation we want to work with.

I have also updated the tests, to reflect how we now use these lists instead of strings.