### PR TITLE
LevelEdges update

### DIFF
--- a/gap/freeband.g
+++ b/gap/freeband.g
@@ -201,7 +201,7 @@ end;
 # the Right method, but since I've still got a few ideas for tidying Right up,
 # I'll wait until then to do this.
 
-LevelEdges := function(w, k radixr, radixl, rightk, leftk, rightm, leftm)
+LevelEdges := function(w, k, radix, rightk, leftk, rightm, leftm)
   local n, outr, outl, i;
   # Takes an input word and a level (size of content), and returns
   # two lists of 4-tuples: a right list and a left list. Right first.
@@ -211,11 +211,26 @@ LevelEdges := function(w, k radixr, radixl, rightk, leftk, rightm, leftm)
   # leftk  = Left(w, k)
   # rightm = Right(w, k-1)
   # leftm  = Left(w, k-1)
-  # radixr = radix called on LevelEdges from level k-1, right list
-  # radixl = radix called on LevelEdges from level k-1, left list
+  # radixr = radix called on LevelEdges from level k-2
   #
   # if this is too difficult then we can call functions inside this one
   # rather than passing input. This risks calculating some things twice.
+
+  if not IsList(w) then
+    ErrorNoReturn("expected a string as the argument, found ", w);
+  fi;
+  if not IsPosInt(k) then
+    ErrorNoReturn("expected a positive integer as second argument");
+  fi;
+  if not k <= Length(w) then
+    ErrorNoReturn("level k cannot be greater than length of word");
+  fi;
+  if not (IsList(radix) and IsList(rightk)
+                        and IsList(leftk)
+                        and IsList(rightm)
+                        and IsList(leftm)) then
+    ErrorNoReturn("expected final five arguments to be lists");
+  fi;
 
   n    := Length(w);
 
@@ -233,21 +248,21 @@ LevelEdges := function(w, k radixr, radixl, rightk, leftk, rightm, leftm)
   else
     for i in [1 .. n] do
       if rightk[i] <> fail then
-        Add(outr, [radixr[i], w[rightm[i] + 1],
-                   w[leftm[rightk[i]] - 1], radixl[rightk[i]]]);
+        Add(outr, [radix[i], w[rightm[i] + 1],
+                   w[leftm[rightk[i]] - 1], radix[rightk[i] + n]]);
       else
         Add(outr, [fail, fail, fail, fail]);
       fi;
 
       if leftk[i] <> fail then
-        Add(outl, [radixr[leftk[i]], w[rightm[leftk[i] + 1],
-                   w[leftm[i] - 1], radixl[i]]);
+        Add(outl, [radix[leftk[i]], w[rightm[leftk[i] + 1]],
+                   w[leftm[i] - 1], radix[i + n]]);
       else
         Add(outl, [fail, fail, fail, fail]);
       fi;
     od;
   fi;
-  return [outr, outl];
+  return Concatenation(outr, outl);
 
 end;
 

--- a/gap/freeband.g
+++ b/gap/freeband.g
@@ -236,14 +236,14 @@ LevelEdges := function(w, k radixr, radixl, rightk, leftk, rightm, leftm)
         Add(outr, [radixr[i], w[rightm[i] + 1],
                    w[leftm[rightk[i]] - 1], radixl[rightk[i]]]);
       else
-        Add(outr, fail);
+        Add(outr, [fail, fail, fail, fail]);
       fi;
 
       if leftk[i] <> fail then
         Add(outl, [radixr[leftk[i]], w[rightm[leftk[i] + 1],
                    w[leftm[i] - 1], radixl[i]]);
       else
-        Add(outl, fail);
+        Add(outl, [fail, fail, fail, fail]);
       fi;
     od;
   fi;

--- a/gap/freeband.g
+++ b/gap/freeband.g
@@ -211,7 +211,7 @@ LevelEdges := function(w, k, radix, rightk, leftk, rightm, leftm)
   # leftk  = Left(w, k)
   # rightm = Right(w, k-1)
   # leftm  = Left(w, k-1)
-  # radixr = radix called on LevelEdges from level k-2
+  # radixr = radix called on LevelEdges from level k-1
   #
   # if this is too difficult then we can call functions inside this one
   # rather than passing input. This risks calculating some things twice.

--- a/gap/test_leveledges.tst
+++ b/gap/test_leveledges.tst
@@ -1,0 +1,35 @@
+#### TEST 1: k=1 trivial output
+gap> t1 := LevelEdges([1, 2, 3], 1, [], [], [], [], []);;
+gap> t2 := [[1, 1, 1, 1],
+>           [1, 2, 2, 1],
+>           [1, 3, 3, 1],
+>           [1, 1, 1, 1],
+>           [1, 2, 2, 1],
+>           [1, 3, 3, 1]];;
+gap> t1 = t2;
+true
+
+#### TEST 2: all-fail input
+gap> t3 := LevelEdges([1, 2, 3], 2, [], [fail, fail, fail], [fail, fail, fail], [], []);;
+gap> t4 := ListWithIdenticalEntries(6, [fail, fail, fail, fail]);;
+gap> t3 = t4;
+true
+
+### TEST 3: first and second half of radix list assignment
+gap> t5 := LevelEdges([0, 0, 0], 2, [1, 1, 1, 2, 2, 2], [2, fail, 2], [2, fail, 2], [2, 2, 2], [2, 2, 2]);;
+gap> t6 := [[1, 0, 0, 2], [fail, fail, fail, fail], [1, 0, 0, 2], [1, 0, 0, 2], [fail, fail, fail, fail], [1, 0, 0, 2]];;
+gap> t5 = t6;
+true
+
+### TEST 4: more involved example, currently with manual radix variable
+gap> b := "aaabcbcbdbcbabcd";;
+gap> radix := [2, 2, 2, 6, 9, 6, 9, 8,
+>              11, 6, 9, 3, 2, 5, 10, fail,
+>              fail, fail, fail, 1, 5, 6, 5, 6,
+>              7, 8, 5, 6, 4, 3, 5, 10];;
+gap> w := StringToStandardListOfPosInts(b);;
+gap> rightk := Right(w, 3);; leftk := Left(w, 3);; rightm := Right(w, 2);; leftm := Left(w, 2);;
+gap> t7 := LevelEdges(w, 3, radix, rightk, leftk, rightm, leftm);;
+gap> t8 := [[2, 3, 1, 6], [2, 3, 1, 6], [2, 3, 1, 6], [6, 4, 4, 6], [9, 4, 4, 6], [6, 4, 4, 6], [9, 4, 4, 6], [8, 3, 4, 6], [11, 3, 4, 6], [6, 1, 1, 5], [9, 1, 1, 5], [3, 3, 1, 5], [2, 3, 1, 5], [5, 4, 2, 10], [fail, fail, fail, fail], [fail, fail, fail, fail], [fail, fail, fail, fail], [fail, fail, fail, fail], [fail, fail, fail, fail], [fail, fail, fail, fail], [2, 2, 1, 5], [2, 2, 1, 6], [2, 2, 1, 5], [2, 2, 1, 6], [6, 2, 3, 7], [6, 2, 3, 8], [6, 2, 4, 5], [6, 2, 4, 6], [6, 2, 3, 4], [6, 2, 3, 3], [6, 2, 1, 5], [5, 4, 2, 10]];;
+gap> t7 = t8;
+true


### PR DESCRIPTION
- All list entries in the output now have the same type: rather than `fail`,  dead entries now contain `[fail, fail, fail, fail]`.

- Add some basic input type tests.

- The radix input is now one list of length 2n; same for output. Right elements first (from 1 to n), then left elements second (n+1 to 2n).